### PR TITLE
events: rename security_inode_unlink device arg

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5170,7 +5170,7 @@ var Definitions = eventDefinitions{
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "pathname"},
 				{Type: "unsigned long", Name: "inode"},
-				{Type: "dev_t", Name: "device"},
+				{Type: "dev_t", Name: "dev"},
 				{Type: "u64", Name: "ctime"},
 			},
 		},


### PR DESCRIPTION
Device arguments are referenced as "dev" in other events. This PR renames "device" to "dev".

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Rename device argument to be dev as all other device arguments in tracee-ebpf

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.